### PR TITLE
chore/optional-viewbuilder - adding extension init

### DIFF
--- a/Sources/SUIComponents/Organisms/PrimaryCardView.swift
+++ b/Sources/SUIComponents/Organisms/PrimaryCardView.swift
@@ -49,6 +49,20 @@ extension Components.Organisms {
     }
 }
 
+extension Components.Organisms.PrimaryCardView where Content == EmptyView {
+    public init(
+        title: String,
+        insets: EdgeInsets = EdgeInsets(padding: .spacer16),
+        itemSpacing: CGFloat = .spacer16) {
+        self.init(
+            title: title,
+            insets: insets,
+            itemSpacing: itemSpacing,
+            content: { EmptyView() }
+        )
+    }
+}
+
 struct PrimaryCardView_Previews: PreviewProvider {
     static var previews: some View {
         HStack(
@@ -59,6 +73,10 @@ struct PrimaryCardView_Previews: PreviewProvider {
                     alignment: .leading,
                     spacing: .spacer16,
                     content: {
+                        Components.Organisms.PrimaryCardView(
+                            title: "A title"
+                        )
+
                         Components.Organisms.PrimaryCardView(
                             title: "A title",
                             content: {


### PR DESCRIPTION
* I noticed that where we use the `@ViewBuilder`, we are forced to pass some views. 
* This allows us to have the content optional.
* `@ViewBuilder` can't be optional with a default value so this seems to be the recommended approach.