### PR TITLE
[CHORE] Fix Tap Area on Secondary Buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Fixed issue with `SecondaryButtonStyle` tap area being too small
 
 ## [1.3.0] - 2023-03-24Z
 - Added `Text` Atom to handle attributed accessibility labels/hints in SwiftUI versions < iOS 15

--- a/Sources/SUIComponents/Helpers/Colours/SemanticColors.swift
+++ b/Sources/SUIComponents/Helpers/Colours/SemanticColors.swift
@@ -84,7 +84,7 @@ extension Color {
         open var textInputBorder = Color(UIColor(darkColour: Color.Named.grey1.uiColour, lightColour: Color.Named.grey1.uiColour))
         open var textInputLeftViewTint = Color(UIColor(darkColour: Color.Named.grey1.uiColour, lightColour: Color.Named.grey1.uiColour))
         open var secondaryButtonText = Color(UIColor(darkColour: Color.Named.blue.uiColour, lightColour: Color.Named.blue.uiColour))
-        open var secondaryButtonBackground = Color(UIColor(darkColour: UIColor.clear, lightColour: UIColor.clear))
+        open var secondaryButtonBackground = Color(UIColor(darkColour: Color.Named.white.uiColour, lightColour: Color.Named.white.uiColour))
         open var secondaryButtonHighlightedBackground = Color(UIColor(darkColour: Color.Named.grey1.uiColour.darken(0.4), lightColour: Color.Named.blue.uiColour.lighten(0.84)))
         open var whiteBackground = Color(UIColor(darkColour: Color.Named.grey3.uiColour, lightColour: Color.Named.white.uiColour))
     }


### PR DESCRIPTION
Having a transparent background made the tap area only the text of the button.

Setting it to `Named.white` allowed the touch area to span the entire button's frame