### PR TITLE
Make `IconButtonView` model public to allow unit tests to trigger tap handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Make `IconButtonView` model public to allow unit tests to trigger tap handler
 
 ## [1.11.1] - 2023-08-31Z
 - Fixed VoiceOver selection on `SelectRowView`

--- a/Sources/SUIComponents/Molecules/IconButtonView.swift
+++ b/Sources/SUIComponents/Molecules/IconButtonView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 extension Components.Molecules {
     public struct IconButtonView: View {
-        let model: Model
+        public let model: Model
 
         @State private var selected: Bool = false
         @State private var currentGeometry: GeometryProxy?


### PR DESCRIPTION
Make `IconButtonView` model public to allow unit tests to trigger tap handler