### PR TITLE
HMA-11260 Support external links and style disclosure icon

### DIFF
--- a/SUICompanionApp/SUICompanionApp/Organisms/ExampleOrganisms.swift
+++ b/SUICompanionApp/SUICompanionApp/Organisms/ExampleOrganisms.swift
@@ -1243,8 +1243,26 @@ extension Components.Organisms.MenuPanelRowView: Examplable {
             disclosureModel: calendarDisclosureModel,
             handler: voidAction
         )
-        
-        let models = [paye, noBodyHelp, annualTaxSummary, messages, manyMessages, noMessages, noMessagesHidden, selfAssessmentNew, hts, calendar]
+        let externalLink = Model(
+            title: "Annual Tax Summary",
+            body: "View your tax and National Insurance contributions and find out how the government spends your taxes.",
+            notificationMode: .hidden,
+            accessibilityHint: "Opens in a web browser.",
+            disclosureModel: disclosureModel,
+            isExternalLink: true,
+            handler: voidAction
+        )
+        let externalLinkNoBody = Model(
+            title: "Annual Tax Summary",
+            body: nil,
+            notificationMode: .hidden,
+            accessibilityHint: "Opens in a web browser.",
+            disclosureModel: disclosureModel,
+            isExternalLink: true,
+            handler: voidAction
+        )
+
+        let models = [paye, noBodyHelp, annualTaxSummary, messages, manyMessages, noMessages, noMessagesHidden, selfAssessmentNew, hts, calendar, externalLink, externalLinkNoBody]
 
         return AnyView (
             ForEach( models, id: \.id ) { model in

--- a/Sources/SUIComponents/Helpers/ViewModifiers/DisclosureView.swift
+++ b/Sources/SUIComponents/Helpers/ViewModifiers/DisclosureView.swift
@@ -67,6 +67,7 @@ public struct DisclosureView: ViewModifier {
                 HStack(spacing: 0) {
                     content.accessibility(sortPriority: 2)
                     model.icon
+                        .font(Font.body.bold())
                         .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: model.inset))
                         .accessibility(hidden: true)
                 }

--- a/Sources/SUIComponents/Organisms/MenuPanelRowView.swift
+++ b/Sources/SUIComponents/Organisms/MenuPanelRowView.swift
@@ -33,7 +33,21 @@ extension Components.Organisms {
         public init(model: Model) {
             self.model = model
         }
-        
+
+        private var disclosureModel: DisclosureView.Model? {
+            guard let baseModel = model.disclosureModel else { return nil }
+            if model.isExternalLink == true {
+                return DisclosureView.Model(
+                    id: baseModel.id,
+                    icon: Image(systemName: "arrow.up.right.square"),
+                    accessibilityLabel: baseModel.accessibilityLabel,
+                    accessibilityHint: baseModel.accessibilityHint,
+                    baseModel.action
+                )
+            }
+            return baseModel
+        }
+
         public var body: some View {
             VStack(alignment: .leading, spacing: .spacer24) {
                 HStack(spacing: .spacer8) {
@@ -81,13 +95,15 @@ extension Components.Organisms.MenuPanelRowView {
         public let accessibilityIdentifier: String?
         public let accessibilityHint: String?
         public let disclosureModel: DisclosureView.Model?
-        
+        public let isExternalLink: Bool?
+
         public init(title: String,
                     body: String? = nil,
                     notificationMode: Components.Molecules.NotificationBubbleView.NotificationMode,
                     accessibilityIdentifier: String? = nil,
                     accessibilityHint: String? = nil,
                     disclosureModel: DisclosureView.Model? = nil,
+                    isExternalLink: Bool? = nil,
                     handler: @escaping VoidHandler
         ) {
             self.title = title
@@ -96,6 +112,7 @@ extension Components.Organisms.MenuPanelRowView {
             self.accessibilityIdentifier = accessibilityIdentifier
             self.accessibilityHint = accessibilityHint
             self.disclosureModel = disclosureModel
+            self.isExternalLink = isExternalLink
             self.action = handler
         }
     }


### PR DESCRIPTION
Add external link icon support to MenuPanelRowView

- Add isExternalLink flag to MenuPanelRowView.Model that replaces the chevron disclosure icon with an external link icon (arrow.up.right.square) when asked.
- Add companion app examples demonstrating external link variants (with and without body text)
- 
<img width="603" height="1311" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-20 at 09 12 53" src="https://github.com/user-attachments/assets/5854b2f2-7f0b-4915-87b0-b562a781ade4" />